### PR TITLE
fix: align dashboard tile heights for consistent layout

### DIFF
--- a/src/pages/dashboard/ActivenessScoreComponent.vue
+++ b/src/pages/dashboard/ActivenessScoreComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card flat bordered class="row q-pa-sm bg-transparent">
+  <q-card flat bordered class="row q-pa-sm bg-transparent full-height" style="height: 100%;">
     <div
       :class="'col ' + ($q.dark.isActive ? 'bg-grey-9' : 'bg-yellow-7')"
       style="max-width: 62px; height: 62px"

--- a/src/pages/dashboard/BytesSendComponent.vue
+++ b/src/pages/dashboard/BytesSendComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card flat bordered class="row q-pa-sm bg-transparent">
+  <q-card flat bordered class="row q-pa-sm bg-transparent full-height" style="height: 100%;">
     <div
       :class="'col ' + ($q.dark.isActive ? 'bg-grey-9' : 'bg-yellow-7')"
       style="max-width: 62px; height: 62px"

--- a/src/pages/dashboard/DashboardPage.vue
+++ b/src/pages/dashboard/DashboardPage.vue
@@ -1,16 +1,16 @@
 <template>
   <q-page padding>
     <div class="row">
-      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs">
+      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs d-flex">
         <ModuleStatusComponent />
       </div>
-      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs">
+      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs d-flex">
         <BytesSendComponent />
       </div>
-      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs">
+      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs d-flex">
         <ActivenessScoreComponent />
       </div>
-      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs">
+      <div class="col-xs-12 col-sm-6 col-lg-3 q-pa-xs d-flex">
         <ItArmyIDComponent />
       </div>
     </div>

--- a/src/pages/dashboard/ItArmyIDComponent.vue
+++ b/src/pages/dashboard/ItArmyIDComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card flat bordered class="row q-pa-sm bg-transparent">
+  <q-card flat bordered class="row q-pa-sm bg-transparent full-height" style="height: 100%;">
     <div
       :class="'col ' + ($q.dark.isActive ? 'bg-grey-9' : 'bg-yellow-7')"
       style="max-width: 62px; height: 62px"

--- a/src/pages/dashboard/ModuleStatusComponent.vue
+++ b/src/pages/dashboard/ModuleStatusComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card flat bordered class="row q-pa-sm bg-transparent">
+  <q-card flat bordered class="row q-pa-sm bg-transparent full-height" style="height: 100%;">
     <div
       :class="'col ' + ($q.dark.isActive ? 'bg-grey-9' : 'bg-yellow-7')"
       style="max-width: 62px; height: 62px"


### PR DESCRIPTION
### 🛠 Bug Fix: Inconsistent tile heights on the dashboard

This pull request addresses an issue where dashboard tiles (showing module status, traffic, Activeness score, IT Army ID) appeared with uneven heights due to varying content length. The issue was particularly noticeable in fullscreen mode, where uneven tile heights disrupted the visual alignment of the layout.

🔧 **Fix:**  
Implemented height alignment across all tiles in the row, ensuring a cleaner and more uniform layout.

📱 **Result:**  
Tiles now maintain consistent height alignment within the row, improving overall visual balance without compromising responsiveness.

<table>
  <tr>
    <td align="center"><strong>Before fix</strong></td>
    <td align="center"><strong>After fix</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/89c160e8-acb4-4fca-99bf-a414e4d6e06b" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/5b62f58f-b928-4f8e-afd3-82ff897a44af" width="100%"></td>
  </tr>
</table>